### PR TITLE
Fixed and augmented trade contract functions for regulator user

### DIFF
--- a/v1/shipment/src/shipment-contract.spec.ts
+++ b/v1/shipment/src/shipment-contract.spec.ts
@@ -74,6 +74,14 @@ describe('ShipmentContract', () => {
             await contract.beforeTransaction(ctx).should.throw;
         });
 
+        it('should not be allowed to proceed due to role not having access to transaction.', async () => {
+            ctx.clientIdentity.getMSPID.returns('ImporterOrgMSP');
+            ctx.clientIdentity.getAttributeValue.withArgs('BUSINESS_ROLE').returns('importer');
+            ctx.stub.getFunctionAndParameters.returns(JSON.parse('{"params":[], "fcn":"getShipmentLocation"}'));
+
+            await contract.beforeTransaction(ctx).should.throw;
+        });
+
         it('should be allowed to proceed and not throw any exceptions.', async () => {
             ctx.clientIdentity.getMSPID.returns('ExporterOrgMSP');
             ctx.clientIdentity.getAttributeValue.withArgs('BUSINESS_ROLE').returns('exporter');

--- a/v1/trade/META-INF/statedb/couchdb/indexes/regulatorIndex.json
+++ b/v1/trade/META-INF/statedb/couchdb/indexes/regulatorIndex.json
@@ -1,0 +1,8 @@
+{
+    "index": {
+        "fields": [ "tradeID" ]
+    },
+    "ddoc": "regulatorIndexDoc",
+    "name": "regulatorIndex",
+    "type": "json"
+}

--- a/v1/trade/src/trade-contract.spec.ts
+++ b/v1/trade/src/trade-contract.spec.ts
@@ -41,6 +41,13 @@ const importerQuery = {
     use_index: ['_design/importerIndexDoc', 'importerIndex'],
 };
 
+const regulatorQuery = {
+    selector: {
+        tradeID: { $regex: '.+' },
+    },
+    use_index: ['_design/regulatorIndexDoc', 'regulatorIndex'],
+};
+
 class TestStateQueryIterator implements Iterators.StateQueryIterator {
     private index: number;
     private resultset: Iterators.KV[];
@@ -99,7 +106,7 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
     let contract: TradeContract;
     let ctx: TestContext;
 
-    async function beforeTestList(exporterObjList: any, importerObjList: any, clientMSP: string) {
+    async function beforeTestList(exporterObjList: any, importerObjList: any, regulatorObjList: any, clientMSP: string) {
         let exporterResultset = [];
         if (exporterObjList !== null) {
             exporterObjList.forEach((exporterObj) => {
@@ -116,14 +123,24 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             });
         }
 
+        let regulatorResultset = [];
+        if (regulatorObjList !== null) {
+            regulatorObjList.forEach((regulatorObj) => {
+                const regulatorJsonStr: string = JSON.stringify(regulatorObj);
+                regulatorResultset = regulatorResultset.concat({ namespace: 'somenamespace', key: 'somekey', value: Buffer.from(regulatorJsonStr)});
+            });
+        }
+
         const exporterIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(exporterResultset);
         const importerIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(importerResultset);
+        const regulatorIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(regulatorResultset);
 
         exporterQuery.selector.exporterMSP = clientMSP;
         importerQuery.selector.importerMSP = clientMSP;
         ctx.clientIdentity.getMSPID.returns(clientMSP);
         ctx.stub.getQueryResult.withArgs(JSON.stringify(exporterQuery)).resolves(exporterIterator);
         ctx.stub.getQueryResult.withArgs(JSON.stringify(importerQuery)).resolves(importerIterator);
+        ctx.stub.getQueryResult.withArgs(JSON.stringify(regulatorQuery)).resolves(regulatorIterator);
     }
 
     beforeEach(() => {
@@ -150,12 +167,25 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
     describe('ImporterOrg reviews his trade requests', () => {
         it('should retrieve their existing trade requests', async () => {
             const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
-            beforeTestList(null, [obj], 'ImporterOrg');
+            beforeTestList(null, [obj], [obj], 'ImporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
         });
 
         it('should return an empty list if they have no trade requests.', async () => {
-            beforeTestList(null, null, 'ImporterOrg');
+            beforeTestList(null, null, null, 'ImporterOrg');
+            await contract.listTrade(ctx).should.eventually.deep.equal([]);
+        });
+    });
+
+    describe('RegulatorOrg reviews recorded trades', () => {
+        it('should retrieve existing trades', async () => {
+            const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
+            beforeTestList(null, [obj], [obj], 'RegulatorOrgMSP');
+            await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
+        });
+
+        it('should return an empty list if there are no recorded trades.', async () => {
+            beforeTestList(null, null, null, 'RegulatorOrgMSP');
             await contract.listTrade(ctx).should.eventually.deep.equal([]);
         });
     });
@@ -164,18 +194,18 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
         it('should retrieve more than one trade requests where they are the exporter', async () => {
             const obj1 = {tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED'};
             const obj2 = {tradeID: '1002', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Oranges', status: 'REQUESTED'};
-            beforeTestList([obj1, obj2], null, 'ExporterOrg');
+            beforeTestList([obj1, obj2], null, [obj1, obj2], 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj1, obj2]);
         });
 
         it('should retrieve existing trade requests where they are the exporter', async () => {
             const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
-            beforeTestList([obj], null, 'ExporterOrg');
+            beforeTestList([obj], null, [obj], 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
         });
 
         it('should return an empty list if they have no requests.', async () => {
-            beforeTestList(null, null, 'ExporterOrg');
+            beforeTestList(null, null, null, 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([]);
         });
 
@@ -234,6 +264,11 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             seconds: Long.fromInt(Math.trunc(date.getTime() / 1000)),
         };
         const dateTsStr = (new Date(dateTs.seconds.toInt() * 1000 + Math.round(dateTs.nanos / 1000000))).toString();
+        const dateTs1 = {
+            nanos: date.getUTCMilliseconds() * 100000,
+            seconds: Math.trunc(date.getTime() / 1000),
+        };
+        const dateTsStr1 = (new Date(dateTs1.seconds * 1000 + Math.round(dateTs1.nanos / 1000000))).toString();
 
         it('should retrieve history of a trade', async () => {
             const obj1 = { tradeID: '1000', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
@@ -254,6 +289,23 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             ctx.stub.getHistoryForKey.withArgs('1000').resolves(importerIterator);
 
             await contract.getTradeHistory(ctx, '1000').should.eventually.deep.equal(importerInvocationResult);
+
+            const exporterObjList = [obj1, obj2];
+
+            let exporterResultset = [];
+            const exporterInvocationResult = [];
+
+            exporterObjList.forEach((exporterObj) => {
+                const exporterJsonStr: string = JSON.stringify(exporterObj);
+                exporterResultset = exporterResultset.concat({ txId: 'someId', timestamp: dateTs1, isDelete: 'false', value: Buffer.from(exporterJsonStr)});
+                exporterInvocationResult.push({ timestamp: dateTsStr1, isDelete: 'false', tradeAgreement: exporterObj, txId: 'someId'});
+            });
+
+            const exporterIterator: Iterators.HistoryQueryIterator = new TestHistoryQueryIterator(exporterResultset);
+
+            ctx.stub.getHistoryForKey.withArgs('1000').resolves(exporterIterator);
+
+            await contract.getTradeHistory(ctx, '1000').should.eventually.deep.equal(exporterInvocationResult);
         });
 
         it('should return an empty list.', async () => {

--- a/v1/trade/src/trade-contract.spec.ts
+++ b/v1/trade/src/trade-contract.spec.ts
@@ -5,6 +5,7 @@
 /* tslint:disable:max-classes-per-file */
 import { Context } from 'fabric-contract-api';
 import { ChaincodeStub, ClientIdentity, Iterators } from 'fabric-shim';
+import Long = require('long');
 import { TradeContract } from '.';
 
 import * as chai from 'chai';
@@ -227,6 +228,13 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
     });
 
     describe('ImporterOrg reviews his trade history', () => {
+        const date = new Date();
+        const dateTs = {
+            nanos: date.getUTCMilliseconds() * 100000,
+            seconds: Long.fromInt(Math.trunc(date.getTime() / 1000)),
+        };
+        const dateTsStr = (new Date(dateTs.seconds.toInt() * 1000 + Math.round(dateTs.nanos / 1000000))).toString();
+
         it('should retrieve history of a trade', async () => {
             const obj1 = { tradeID: '1000', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
             const obj2 = { tradeID: '1000', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'ACCEPTED' };
@@ -237,8 +245,8 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
 
             importerObjList.forEach((importerObj) => {
                 const importerJsonStr: string = JSON.stringify(importerObj);
-                importerResultset = importerResultset.concat({ txId: 'someId', timestamp: 'someTs', isDelete: 'false', value: Buffer.from(importerJsonStr)});
-                importerInvocationResult.push({ timestamp: 'someTs', isDelete: 'false', tradeAgreement: importerObj, txId: 'someId'});
+                importerResultset = importerResultset.concat({ txId: 'someId', timestamp: dateTs, isDelete: 'false', value: Buffer.from(importerJsonStr)});
+                importerInvocationResult.push({ timestamp: dateTsStr, isDelete: 'false', tradeAgreement: importerObj, txId: 'someId'});
             });
 
             const importerIterator: Iterators.HistoryQueryIterator = new TestHistoryQueryIterator(importerResultset);

--- a/v2/shipment/package.json
+++ b/v2/shipment/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "lint": "tslint -c tslint.json 'src/**/*.ts'",
         "pretest": "npm run lint",
-        "test": "nyc mocha -r ts-node/register src/**/*.spec.ts",
+        "test": "nyc --reporter=lcov --reporter=text-summary mocha -r ts-node/register src/**/*.spec.ts",
         "start": "fabric-chaincode-node start",
         "build": "tsc",
         "build:watch": "tsc -w"

--- a/v2/shipment/src/shipment-contract.spec.ts
+++ b/v2/shipment/src/shipment-contract.spec.ts
@@ -69,6 +69,14 @@ describe('ShipmentContract', () => {
         it('should not be allowed to proceed due to role not having access to transaction.', async () => {
             ctx.clientIdentity.getMSPID.returns('ImporterOrgMSP');
             ctx.clientIdentity.getAttributeValue.withArgs('BUSINESS_ROLE').returns('importer');
+            ctx.stub.getFunctionAndParameters.returns(JSON.parse('{"params":[], "fcn":"prepareShipment"}'));
+
+            await contract.beforeTransaction(ctx).should.throw;
+        });
+
+        it('should not be allowed to proceed due to role not having access to transaction.', async () => {
+            ctx.clientIdentity.getMSPID.returns('ImporterOrgMSP');
+            ctx.clientIdentity.getAttributeValue.withArgs('BUSINESS_ROLE').returns('importer');
             ctx.stub.getFunctionAndParameters.returns(JSON.parse('{"params":[], "fcn":"getShipmentLocation"}'));
 
             await contract.beforeTransaction(ctx).should.throw;

--- a/v2/trade/package.json
+++ b/v2/trade/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "lint": "tslint -c tslint.json 'src/**/*.ts'",
         "pretest": "npm run lint",
-        "test": "nyc mocha -r ts-node/register src/**/*.spec.ts",
+        "test": "nyc --reporter=lcov --reporter=text-summary mocha -r ts-node/register src/**/*.spec.ts",
         "start": "fabric-chaincode-node start",
         "build": "tsc",
         "build:watch": "tsc -w"

--- a/v2/trade/src/trade-contract.spec.ts
+++ b/v2/trade/src/trade-contract.spec.ts
@@ -41,6 +41,13 @@ const importerQuery = {
     use_index: ['_design/importerIndexDoc', 'importerIndex'],
 };
 
+const regulatorQuery = {
+    selector: {
+        tradeID: { $regex: '.+' },
+    },
+    use_index: ['_design/regulatorIndexDoc', 'regulatorIndex'],
+};
+
 class TestStateQueryIterator implements Iterators.StateQueryIterator {
     private index: number;
     private resultset: Iterators.KV[];
@@ -99,7 +106,7 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
     let contract: TradeContract;
     let ctx: TestContext;
 
-    async function beforeTestList(exporterObjList: any, importerObjList: any, clientMSP: string) {
+    async function beforeTestList(exporterObjList: any, importerObjList: any, regulatorObjList: any, clientMSP: string) {
         let exporterResultset = [];
         if (exporterObjList !== null) {
             exporterObjList.forEach((exporterObj) => {
@@ -116,14 +123,24 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             });
         }
 
+        let regulatorResultset = [];
+        if (regulatorObjList !== null) {
+            regulatorObjList.forEach((regulatorObj) => {
+                const regulatorJsonStr: string = JSON.stringify(regulatorObj);
+                regulatorResultset = regulatorResultset.concat({ namespace: 'somenamespace', key: 'somekey', value: Buffer.from(regulatorJsonStr)});
+            });
+        }
+
         const exporterIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(exporterResultset);
         const importerIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(importerResultset);
+        const regulatorIterator: Iterators.StateQueryIterator = new TestStateQueryIterator(regulatorResultset);
 
         exporterQuery.selector.exporterMSP = clientMSP;
         importerQuery.selector.importerMSP = clientMSP;
         ctx.clientIdentity.getMSPID.returns(clientMSP);
         ctx.stub.getQueryResult.withArgs(JSON.stringify(exporterQuery)).resolves(exporterIterator);
         ctx.stub.getQueryResult.withArgs(JSON.stringify(importerQuery)).resolves(importerIterator);
+        ctx.stub.getQueryResult.withArgs(JSON.stringify(regulatorQuery)).resolves(regulatorIterator);
     }
 
     beforeEach(() => {
@@ -150,12 +167,25 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
     describe('ImporterOrg reviews his trade requests', () => {
         it('should retrieve their existing trade requests', async () => {
             const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
-            beforeTestList(null, [obj], 'ImporterOrg');
+            beforeTestList(null, [obj], [obj], 'ImporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
         });
 
         it('should return an empty list if they have no trade requests.', async () => {
-            beforeTestList(null, null, 'ImporterOrg');
+            beforeTestList(null, null, null, 'ImporterOrg');
+            await contract.listTrade(ctx).should.eventually.deep.equal([]);
+        });
+    });
+
+    describe('RegulatorOrg reviews recorded trades', () => {
+        it('should retrieve existing trades', async () => {
+            const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
+            beforeTestList(null, [obj], [obj], 'RegulatorOrgMSP');
+            await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
+        });
+
+        it('should return an empty list if there are no recorded trades.', async () => {
+            beforeTestList(null, null, null, 'RegulatorOrgMSP');
             await contract.listTrade(ctx).should.eventually.deep.equal([]);
         });
     });
@@ -164,18 +194,18 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
         it('should retrieve more than one trade requests where they are the exporter', async () => {
             const obj1 = {tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED'};
             const obj2 = {tradeID: '1002', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Oranges', status: 'REQUESTED'};
-            beforeTestList([obj1, obj2], null, 'ExporterOrg');
+            beforeTestList([obj1, obj2], null, [obj1, obj2], 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj1, obj2]);
         });
 
         it('should retrieve existing trade requests where they are the exporter', async () => {
             const obj = { tradeID: '1001', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
-            beforeTestList([obj], null, 'ExporterOrg');
+            beforeTestList([obj], null, [obj], 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([obj]);
         });
 
         it('should return an empty list if they have no requests.', async () => {
-            beforeTestList(null, null, 'ExporterOrg');
+            beforeTestList(null, null, null, 'ExporterOrg');
             await contract.listTrade(ctx).should.eventually.deep.equal([]);
         });
 
@@ -234,6 +264,11 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             seconds: Long.fromInt(Math.trunc(date.getTime() / 1000)),
         };
         const dateTsStr = (new Date(dateTs.seconds.toInt() * 1000 + Math.round(dateTs.nanos / 1000000))).toString();
+        const dateTs1 = {
+            nanos: date.getUTCMilliseconds() * 100000,
+            seconds: Math.trunc(date.getTime() / 1000),
+        };
+        const dateTsStr1 = (new Date(dateTs1.seconds * 1000 + Math.round(dateTs1.nanos / 1000000))).toString();
 
         it('should retrieve history of a trade', async () => {
             const obj1 = { tradeID: '1000', exporterMSP: 'ExporterOrg', importerMSP: 'ImporterOrg', amount: 1000.0, descriptionOfGoods: 'Apples', status: 'REQUESTED' };
@@ -254,6 +289,23 @@ describe('As an importer, I can enter in a trade agreement with an exporter to a
             ctx.stub.getHistoryForKey.withArgs('1000').resolves(importerIterator);
 
             await contract.getTradeHistory(ctx, '1000').should.eventually.deep.equal(importerInvocationResult);
+
+            const exporterObjList = [obj1, obj2];
+
+            let exporterResultset = [];
+            const exporterInvocationResult = [];
+
+            exporterObjList.forEach((exporterObj) => {
+                const exporterJsonStr: string = JSON.stringify(exporterObj);
+                exporterResultset = exporterResultset.concat({ txId: 'someId', timestamp: dateTs1, isDelete: 'false', value: Buffer.from(exporterJsonStr)});
+                exporterInvocationResult.push({ timestamp: dateTsStr1, isDelete: 'false', tradeAgreement: exporterObj, txId: 'someId'});
+            });
+
+            const exporterIterator: Iterators.HistoryQueryIterator = new TestHistoryQueryIterator(exporterResultset);
+
+            ctx.stub.getHistoryForKey.withArgs('1000').resolves(exporterIterator);
+
+            await contract.getTradeHistory(ctx, '1000').should.eventually.deep.equal(exporterInvocationResult);
         });
 
         it('should return an empty list.', async () => {


### PR DESCRIPTION
Updated 'listTrade' to support queries from regulators, using indices.
Fixed logic and unit test for 'getTradeHistory', which was failing.
Added 'getTradeHistory' and 'getTradesByRange' to v2 trade contract.